### PR TITLE
Fixed some game-breaking Lingo decompilation bugs

### DIFF
--- a/src/director/handler.cpp
+++ b/src/director/handler.cpp
@@ -644,15 +644,15 @@ uint32_t Handler::translateBytecode(Bytecode &bytecode, uint32_t index) {
 		break;
 	case kOpOntoSpr:
 		{
-			auto firstSprite = pop();
 			auto secondSprite = pop();
+			auto firstSprite = pop();
 			translation = std::make_shared<SpriteIntersectsExprNode>(std::move(firstSprite), std::move(secondSprite));
 		}
 		break;
 	case kOpIntoSpr:
 		{
-			auto firstSprite = pop();
 			auto secondSprite = pop();
+			auto firstSprite = pop();
 			translation = std::make_shared<SpriteWithinExprNode>(std::move(firstSprite), std::move(secondSprite));
 		}
 		break;

--- a/src/director/handler.cpp
+++ b/src/director/handler.cpp
@@ -373,7 +373,7 @@ void Handler::tagLoops() {
 		uint32_t jmpPos = jmpifz.pos + jmpifz.obj;
 		uint32_t endIndex = bytecodePosMap[jmpPos];
 		auto &endRepeat = bytecodeArray[endIndex - 1];
-		if (endRepeat.opcode != kOpEndRepeat)
+		if (endRepeat.opcode != kOpEndRepeat || (endRepeat.pos - endRepeat.obj) > jmpifz.pos)
 			continue;
 
 		BytecodeTag loopType = identifyLoop(startIndex, endIndex);

--- a/src/director/lingo.cpp
+++ b/src/director/lingo.cpp
@@ -564,7 +564,8 @@ std::string NotOpNode::toString(bool dot, bool sum) {
 
 std::string BinaryOpNode::toString(bool dot, bool sum) {
 	auto opString = Lingo::getName(Lingo::binaryOpNames, opcode);
-	return left->toString(dot, sum) + " " +  opString + " " + right->toString(dot, sum);
+	// added "(" and ")" to fix op. precedence problems (not always needed, it can be improved)
+	return "(" + left->toString(dot, sum) + " " +  opString + " " + right->toString(dot, sum) + ")";
 }
 
 /* ChunkExprNode */

--- a/src/director/lingo.h
+++ b/src/director/lingo.h
@@ -281,8 +281,8 @@ struct Handler {
 	uint32_t argumentOffset;
 	uint16_t localsCount;
 	uint32_t localsOffset;
-	uint16_t unknown0Count;
-	uint32_t unknown0Offset;
+	uint16_t globalsCount;
+	uint32_t globalsOffset;
 	uint32_t unknown1;
 	uint16_t unknown2;
 	uint16_t lineCount;
@@ -291,6 +291,7 @@ struct Handler {
 
 	std::vector<int16_t> argumentNameIDs;
 	std::vector<int16_t> localNameIDs;
+	std::vector<int16_t> globalNameIDs;
 
 	ScriptChunk *script;
 	std::vector<Bytecode> bytecodeArray;
@@ -318,7 +319,6 @@ struct Handler {
 	std::shared_ptr<Node> peek();
 	std::shared_ptr<Node> pop();
 	int variableMultiplier();
-	void registerGlobal(const std::string &name);
 	std::shared_ptr<Node> readVar(int varType);
 	std::string getVarNameFromSet(const Bytecode &bytecode);
 	std::shared_ptr<Node> readV4Property(int propertyType, int propertyID);


### PR DESCRIPTION
I did some bug fixes for the Lingo decompilation including:

* Operator precedence issues. Example: "(var1 +var2) / var3" was decompiled as "var1 +var2 / var3"
* Sprite "within" operation was reversed. Example: "sprite 1 within 2" was decompiled as "sprite 2 within 1"
* Globals on handlers were ignored and named as "unknown0". Globals were explored on the handler instead, but this was breaking some do("string evaluated code") calls.
* Logic like:
```
if (cond1) then
    ...
    repeat while (cond2)
        ...
    end repeat
end if
```

was decompiled as:
```
repeat while (cond1)
    ...
    repeat while (cond2)
        ...
    end repeat
end repeat
```