### PR TITLE
Add support for opcode 0x73

### DIFF
--- a/src/director/handler.cpp
+++ b/src/director/handler.cpp
@@ -1187,6 +1187,13 @@ uint32_t Handler::translateBytecode(Bytecode &bytecode, uint32_t index) {
 			translation = std::make_shared<VarNode>(name);
 		}
 		break;
+	case kOpNewObj:
+		{
+			auto objType = getName(bytecode.obj);
+			auto objArgs = pop();
+			translation = std::make_shared<NewObjNode>(objType, std::move(objArgs));
+		}
+		break;
 	default:
 		{
 			auto commentText = Lingo::getOpcodeName(bytecode.opID);

--- a/src/director/lingo.cpp
+++ b/src/director/lingo.cpp
@@ -101,7 +101,8 @@ std::map<unsigned int, std::string> Lingo::opcodeNames = {
 	{ kOpPushInt32,			"pushint32" },
 	{ kOpGetChainedProp,	"getchainedprop" },
 	{ kOpPushFloat32,		"pushfloat32" },
-	{ kOpGetTopLevelProp,	"gettoplevelprop" }
+	{ kOpGetTopLevelProp,   "gettoplevelprop" },
+	{ kOpNewObj,			"newobj" }
 };
 
 std::map<unsigned int, std::string> Lingo::binaryOpNames = {
@@ -949,6 +950,12 @@ std::string WhenStmtNode::toString(bool, bool) {
 	}
 
 	return res;
+}
+
+/* NewObjNode */
+
+std::string NewObjNode::toString(bool dot, bool sum) {
+	return "new " + objType + "(" + objArgs->toString(dot, sum) + ")";
 }
 
 }

--- a/src/director/lingo.h
+++ b/src/director/lingo.h
@@ -121,7 +121,8 @@ enum OpCode {
 	kOpPushInt32		= 0x6f,
 	kOpGetChainedProp	= 0x70,
 	kOpPushFloat32		= 0x71,
-	kOpGetTopLevelProp	= 0x72
+	kOpGetTopLevelProp	= 0x72,
+	kOpNewObj		= 0x73
 };
 
 enum DatumType {
@@ -194,7 +195,8 @@ enum NodeType {
 	kExitRepeatStmtNode,
 	kNextRepeatStmtNode,
 	kPutStmtNode,
-	kWhenStmtNode
+	kWhenStmtNode,
+	kNewObjNode
 };
 
 enum BytecodeTag {
@@ -1063,6 +1065,17 @@ struct WhenStmtNode : StmtNode {
 	WhenStmtNode(int e, std::string s)
 		: StmtNode(kWhenStmtNode), event(e), script(s) {}
 	virtual ~WhenStmtNode() = default;
+	virtual std::string toString(bool dot, bool sum);
+};
+
+/* NewObjNode */
+
+struct NewObjNode : ExprNode {
+ std::string objType;
+ std::shared_ptr<Node> objArgs;
+
+	NewObjNode(std::string o, std::shared_ptr<Node> args) : ExprNode(kNewObjNode), objType(o), objArgs(args) {}
+	virtual ~NewObjNode() = default;
 	virtual std::string toString(bool dot, bool sum);
 };
 


### PR DESCRIPTION
This adds support for 0x73 - which to the best of my knowledge is when a new object is created.

As far as I can tell there is no mention of this opcode anywhere, so I've tried my best to sort of guess how it's supposed to be handled, but I am extremely confident that it does the job perfectly. 

I noticed this myself after running this through some of my own scripts and seeing different output than what I expected.

So for example
```
on exitFrame
  scriptTest = new script("value")
  timeoutTest = new timeout("timeout", 50, "sampleTimeout", 0)
end
```

was decompiled as
```
on exitFrame
  -- unk73 4
  scriptTest = ERROR
  -- unk73 2
  timeoutTest = ERROR
end
```
