### PR TITLE
Fixes, fixes, and more fixes ✨

### DIFF
--- a/src/director/chunk.cpp
+++ b/src/director/chunk.cpp
@@ -329,6 +329,10 @@ void CastInfoChunk::read(Common::ReadStream &stream) {
 	// cProp19 = readProperty(19);
 	// cProp20 = readProperty(20);
 	// imageCompression = readProperty(21);
+	if (offsetTableLen == 0) {		//Workarround: Increase TableLen to have at least one entry for decompilation results
+		offsetTableLen = 1;
+		offsetTable.resize(offsetTableLen);
+	}
 }
 
 void CastInfoChunk::readHeader(Common::ReadStream &stream) {

--- a/src/director/handler.cpp
+++ b/src/director/handler.cpp
@@ -644,15 +644,15 @@ uint32_t Handler::translateBytecode(Bytecode &bytecode, uint32_t index) {
 		break;
 	case kOpOntoSpr:
 		{
-			auto firstSprite = pop();
 			auto secondSprite = pop();
+			auto firstSprite = pop();
 			translation = std::make_shared<SpriteIntersectsExprNode>(std::move(firstSprite), std::move(secondSprite));
 		}
 		break;
 	case kOpIntoSpr:
 		{
-			auto firstSprite = pop();
 			auto secondSprite = pop();
+			auto firstSprite = pop();
 			translation = std::make_shared<SpriteWithinExprNode>(std::move(firstSprite), std::move(secondSprite));
 		}
 		break;

--- a/src/director/handler.cpp
+++ b/src/director/handler.cpp
@@ -344,14 +344,14 @@ std::shared_ptr<Node> Handler::readChunkRef(std::shared_ptr<Node> string) {
 	auto lastChar = pop();
 	auto firstChar = pop();
 
-	if (!(firstChar->type == kLiteralNode && firstChar->getValue()->type == kDatumInt && firstChar->getValue()->toInt() == 0))
-		return std::make_shared<ChunkExprNode>(kChunkChar, std::move(firstChar), std::move(lastChar), std::move(string));
-	if (!(firstWord->type == kLiteralNode && firstWord->getValue()->type == kDatumInt && firstWord->getValue()->toInt() == 0))
-		return std::make_shared<ChunkExprNode>(kChunkWord, std::move(firstWord), std::move(lastWord), std::move(string));
-	if (!(firstItem->type == kLiteralNode && firstItem->getValue()->type == kDatumInt && firstItem->getValue()->toInt() == 0))
-		return std::make_shared<ChunkExprNode>(kChunkItem, std::move(firstItem), std::move(lastItem), std::move(string));
 	if (!(firstLine->type == kLiteralNode && firstLine->getValue()->type == kDatumInt && firstLine->getValue()->toInt() == 0))
-		return std::make_shared<ChunkExprNode>(kChunkLine, std::move(firstLine), std::move(lastLine), std::move(string));
+		string = std::make_shared<ChunkExprNode>(kChunkLine, std::move(firstLine), std::move(lastLine), std::move(string));
+	if (!(firstItem->type == kLiteralNode && firstItem->getValue()->type == kDatumInt && firstItem->getValue()->toInt() == 0))
+		string = std::make_shared<ChunkExprNode>(kChunkItem, std::move(firstItem), std::move(lastItem), std::move(string));
+	if (!(firstWord->type == kLiteralNode && firstWord->getValue()->type == kDatumInt && firstWord->getValue()->toInt() == 0))
+		string = std::make_shared<ChunkExprNode>(kChunkWord, std::move(firstWord), std::move(lastWord), std::move(string));
+	if (!(firstChar->type == kLiteralNode && firstChar->getValue()->type == kDatumInt && firstChar->getValue()->toInt() == 0))
+		string = std::make_shared<ChunkExprNode>(kChunkChar, std::move(firstChar), std::move(lastChar), std::move(string));
 
 	return string;
 }

--- a/src/director/handler.cpp
+++ b/src/director/handler.cpp
@@ -373,7 +373,7 @@ void Handler::tagLoops() {
 		uint32_t jmpPos = jmpifz.pos + jmpifz.obj;
 		uint32_t endIndex = bytecodePosMap[jmpPos];
 		auto &endRepeat = bytecodeArray[endIndex - 1];
-		if (endRepeat.opcode != kOpEndRepeat)
+		if (endRepeat.opcode != kOpEndRepeat || (endRepeat.pos - endRepeat.obj) > jmpifz.pos)
 			continue;
 
 		BytecodeTag loopType = identifyLoop(startIndex, endIndex);

--- a/src/director/handler.cpp
+++ b/src/director/handler.cpp
@@ -289,6 +289,14 @@ std::shared_ptr<Node> Handler::readV4Property(int propertyType, int propertyID) 
 	case 0x07: // animation property
 		return std::make_shared<TheExprNode>(Lingo::getName(Lingo::animationPropertyNames, propertyID));
 	case 0x08: // animation 2 property
+		if (propertyID == 0x02 && script->dir->version >= 500) {	//The number of castMembers supports castLib selection from Director 5.0
+			auto castLib = pop();
+			if (!(castLib->type == kLiteralNode && castLib->getValue()->type == kDatumInt && castLib->getValue()->toInt() == 0))
+			{
+				auto castLibNode = std::make_shared<MemberExprNode>("castLib",castLib, nullptr);
+				return std::make_shared<ThePropExprNode>(castLibNode, Lingo::getName(Lingo::animation2PropertyNames, propertyID));
+			}
+		}
 		return std::make_shared<TheExprNode>(Lingo::getName(Lingo::animation2PropertyNames, propertyID));
 	case 0x09: // generic cast member
 	case 0x0a: // chunk of cast member

--- a/src/director/lingo.cpp
+++ b/src/director/lingo.cpp
@@ -843,7 +843,12 @@ std::string CallNode::toString(bool dot, bool sum) {
 
 std::string ObjCallNode::toString(bool dot, bool sum) {
 	auto rawArgs = argList->getValue()->l;
-	std::string res = rawArgs[0]->toString(dot, sum) + "." + name + "(";
+	auto obj = rawArgs[0];
+	std::string leftOp = obj->toString(dot, sum);
+	if (obj->type != kVarNode && obj->type != kObjCallNode && obj->type != kObjCallV4Node && obj->type != kCallNode &&
+			obj->type != kObjPropExprNode && obj->type != kObjBracketExprNode && obj->type != kObjPropIndexExprNode)
+		leftOp = "(" + leftOp + ")";
+	std::string res = leftOp + "." + name + "(";
 	for (size_t i = 1; i < rawArgs.size(); i++) {
 		if (i > 1)
 			res += ", ";
@@ -919,9 +924,13 @@ std::string ThePropExprNode::toString(bool, bool sum) {
 /* ObjPropExprNode */
 
 std::string ObjPropExprNode::toString(bool dot, bool sum) {
-	if (dot)
-		return obj->toString(dot, sum) + "." + prop;
-
+	if (dot) {
+		std::string leftOp = obj->toString(dot, sum);
+		if (obj->type != kVarNode && obj->type != kObjCallNode && obj->type != kObjCallV4Node && obj->type != kCallNode &&
+				obj->type != kObjPropExprNode && obj->type != kObjBracketExprNode && obj->type != kObjPropIndexExprNode)
+			leftOp = "(" + leftOp + ")";
+		return leftOp + "." + prop;
+	}
 	return "the " + prop + " of " + obj->toString(dot, sum);
 }
 
@@ -934,7 +943,11 @@ std::string ObjBracketExprNode::toString(bool dot, bool sum) {
 /* ObjPropIndexExprNode */
 
 std::string ObjPropIndexExprNode::toString(bool dot, bool sum) {
-	std::string res = obj->toString(dot, sum) + "." + prop + "[" + index->toString(dot, sum);
+	std::string leftOp = obj->toString(dot, sum);
+	if (obj->type != kVarNode && obj->type != kObjCallNode && obj->type != kObjCallV4Node && obj->type != kCallNode &&
+			obj->type != kObjPropExprNode && obj->type != kObjBracketExprNode && obj->type != kObjPropIndexExprNode)
+		leftOp = "(" + leftOp + ")";
+	std::string res = leftOp + "." + prop + "[" + index->toString(dot, sum);
 	if (index2)
 		res += ".." + index2->toString(dot, sum);
 	res += "]";

--- a/src/director/lingo.cpp
+++ b/src/director/lingo.cpp
@@ -552,12 +552,16 @@ std::string ExitStmtNode::toString(bool, bool) {
 /* InverseOpNode */
 
 std::string InverseOpNode::toString(bool dot, bool sum) {
+	if (operand->type == kBinaryOpNode)
+		return "-(" + operand->toString(dot, sum) + ")";
 	return "-" + operand->toString(dot, sum);
 }
 
 /* NotOpNode */
 
 std::string NotOpNode::toString(bool dot, bool sum) {
+	if (operand->type == kBinaryOpNode)
+		return "not (" + operand->toString(dot, sum) + ")";
 	return "not " + operand->toString(dot, sum);
 }
 
@@ -565,8 +569,48 @@ std::string NotOpNode::toString(bool dot, bool sum) {
 
 std::string BinaryOpNode::toString(bool dot, bool sum) {
 	auto opString = Lingo::getName(Lingo::binaryOpNames, opcode);
-	// added "(" and ")" to fix op. precedence problems (not always needed, it can be improved)
-	return "(" + left->toString(dot, sum) + " " +  opString + " " + right->toString(dot, sum) + ")";
+	std::string leftString = left->toString(dot, sum);
+	std::string rightString = right->toString(dot, sum);
+	unsigned int priority = getPriority();
+	if (priority) {
+		if (left->type == kBinaryOpNode) {
+			auto leftBinaryOpNode = static_cast<BinaryOpNode *>(left.get());
+			if (leftBinaryOpNode->getPriority() > priority)
+				leftString = "(" + leftString + ")";
+		}
+		if (right->type == kBinaryOpNode) {
+			auto rightBinaryOpNode = static_cast<BinaryOpNode *>(right.get());
+			if (rightBinaryOpNode->getPriority() >= priority)
+				rightString = "(" + rightString + ")";
+		}
+	}
+	return leftString + " " +  opString + " " + rightString;
+}
+
+unsigned int BinaryOpNode::getPriority() {
+	switch (opcode) {
+	case kOpMul:
+	case kOpDiv:
+	case kOpMod:
+		return 1;
+	case kOpAdd:
+	case kOpSub:
+		return 2;
+	case kOpLt:
+	case kOpLtEq:
+	case kOpNtEq:
+	case kOpEq:
+	case kOpGt:
+	case kOpGtEq:
+		return 3;
+	case kOpAnd:
+		return 4;
+	case kOpOr:
+		return 5;
+	default:
+		break;
+	}
+	return 0;
 }
 
 /* ChunkExprNode */
@@ -612,6 +656,8 @@ std::string MemberExprNode::toString(bool dot, bool sum) {
 	if (!castID || (castID->type == kLiteralNode && castID->getValue()->type == kDatumInt && castID->getValue()->i == 0)) {
 		if (dot) {
 			res += "(" + memberID->toString(dot, sum) + ")";
+		} else if (memberID->type == kBinaryOpNode) {
+			res += " (" + memberID->toString(dot, sum) + ")";
 		} else {
 			res += " " + memberID->toString(dot, sum);
 		}

--- a/src/director/lingo.cpp
+++ b/src/director/lingo.cpp
@@ -564,7 +564,8 @@ std::string NotOpNode::toString(bool dot, bool sum) {
 
 std::string BinaryOpNode::toString(bool dot, bool sum) {
 	auto opString = Lingo::getName(Lingo::binaryOpNames, opcode);
-	return left->toString(dot, sum) + " " +  opString + " " + right->toString(dot, sum);
+	// added "(" and ")" to fix op. precedence problems (not always needed, it can be improved)
+	return "(" + left->toString(dot, sum) + " " +  opString + " " + right->toString(dot, sum) + ")";
 }
 
 /* ChunkExprNode */

--- a/src/director/lingo.h
+++ b/src/director/lingo.h
@@ -526,6 +526,7 @@ struct BinaryOpNode : ExprNode {
 	}
 	virtual ~BinaryOpNode() = default;
 	virtual std::string toString(bool dot, bool sum);
+	virtual unsigned int getPriority();
 };
 
 /* ChunkExprNode */

--- a/src/director/lingo.h
+++ b/src/director/lingo.h
@@ -281,8 +281,8 @@ struct Handler {
 	uint32_t argumentOffset;
 	uint16_t localsCount;
 	uint32_t localsOffset;
-	uint16_t unknown0Count;
-	uint32_t unknown0Offset;
+	uint16_t globalsCount;
+	uint32_t globalsOffset;
 	uint32_t unknown1;
 	uint16_t unknown2;
 	uint16_t lineCount;
@@ -291,6 +291,7 @@ struct Handler {
 
 	std::vector<int16_t> argumentNameIDs;
 	std::vector<int16_t> localNameIDs;
+	std::vector<int16_t> globalNameIDs;
 
 	ScriptChunk *script;
 	std::vector<Bytecode> bytecodeArray;
@@ -318,7 +319,6 @@ struct Handler {
 	std::shared_ptr<Node> peek();
 	std::shared_ptr<Node> pop();
 	int variableMultiplier();
-	void registerGlobal(const std::string &name);
 	std::shared_ptr<Node> readVar(int varType);
 	std::string getVarNameFromSet(const Bytecode &bytecode);
 	std::shared_ptr<Node> readV4Property(int propertyType, int propertyID);


### PR DESCRIPTION
I've just added a new commit were I've fixed something like `item 1 of line 5 of myString` to be decompiled as `item 1 of myString`. The same issue happened with more complex statements like `char 1 to 2 of word 3 to 4 of item 5 to 6 of line 7 to 8 of myString` being decompiled as `char 1 to 2 of myString` 