### PR TITLE
Always include cast ID in filename for dumping scripts

### DIFF
--- a/src/director/dirfile.cpp
+++ b/src/director/dirfile.cpp
@@ -786,9 +786,10 @@ void DirectorFile::dumpScripts() {
 				} else {
 					scriptType = "CastScript";
 				}
-				id = member->getName().empty()
-					? std::to_string(member->id)
-					: member->getName();
+				id = std::to_string(member->id);
+				if (!member->getName().empty()) {
+					id += " - " + member->getName();
+				}
 			} else {
 				scriptType = "UnknownScript";
 				id = std::to_string(it->first);


### PR DESCRIPTION
A small change; quite a lot of Director files alternate between using names and cast IDs for calling other scripts, so including the cast ID in the dump filenames is really useful when reversing.