### PR TITLE
Call mpg123_init for compatibility

### DIFF
--- a/src/director/sound.cpp
+++ b/src/director/sound.cpp
@@ -61,6 +61,13 @@ bool decodeMP3(
 	int err;
 	mpg123_handle *mh;
 
+	// initialize mpg123 (required for compatibility with older mpg123 versions)
+	err = mpg123_init();
+	if (err != MPG123_OK) {
+		Common::warning(boost::format("mpg123_init: %s") % mpg123_plain_strerror(err));
+		return false;
+	}
+
 	// initialize an mpg123 handle
 	if ((mh = mpg123_new(NULL, &err)) == NULL) {
 		Common::warning(boost::format("mpg123_new: %s") % mpg123_plain_strerror(err));


### PR DESCRIPTION
mpg123_init is required for older API versions before 46 (mpg123 1.27.0)

See: https://www.mpg123.de/api/group__mpg123__init.shtml#gad59b5dc08fb7551ef5ec085906a85604